### PR TITLE
feat: add flowbite dark mode theming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,15 @@
       "version": "0.0.1",
       "dependencies": {
         "@dagrejs/dagre": "^1.0.9",
-        "@xyflow/svelte": "^0.1.25"
+        "@xyflow/svelte": "^0.1.25",
+        "flowbite": "^2.5.2",
+        "flowbite-svelte": "^0.46.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^3.0.2",
         "@tsconfig/svelte": "^5.0.2",
         "@types/dagre": "^0.7.51",
+        "@types/node": "^24.5.2",
         "autoprefixer": "^10.4.19",
         "postcss": "^8.4.38",
         "svelte": "^4.2.15",
@@ -460,6 +463,31 @@
         "node": ">=12"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -560,6 +588,80 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
+      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -989,11 +1091,27 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
     "node_modules/@types/pug": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.10.tgz",
       "integrity": "sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "license": "MIT"
     },
     "node_modules/@xyflow/svelte": {
@@ -1024,6 +1142,12 @@
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0"
       }
+    },
+    "node_modules/@yr/monotone-cubic-spline": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
+      "integrity": "sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA==",
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -1082,6 +1206,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/apexcharts": {
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.54.1.tgz",
+      "integrity": "sha512-E4et0h/J1U3r3EwS/WlqJCQIbepKbp6wGUmaAwJOMjHUP4Ci0gxanLa7FR3okx6p9coi4st6J853/Cb1NP0vpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@yr/monotone-cubic-spline": "^1.0.3",
+        "svg.draggable.js": "^2.2.2",
+        "svg.easing.js": "^2.0.0",
+        "svg.filter.js": "^2.0.2",
+        "svg.pathmorphing.js": "^0.1.3",
+        "svg.resize.js": "^1.4.3",
+        "svg.select.js": "^3.0.1"
       }
     },
     "node_modules/arg": {
@@ -1525,7 +1664,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1681,6 +1819,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/flowbite": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/flowbite/-/flowbite-2.5.2.tgz",
+      "integrity": "sha512-kwFD3n8/YW4EG8GlY3Od9IoKND97kitO+/ejISHSqpn3vw2i5K/+ZI8Jm2V+KC4fGdnfi0XZ+TzYqQb4Q1LshA==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.9.3",
+        "flowbite-datepicker": "^1.3.0",
+        "mini-svg-data-uri": "^1.4.3"
+      }
+    },
+    "node_modules/flowbite-datepicker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/flowbite-datepicker/-/flowbite-datepicker-1.3.2.tgz",
+      "integrity": "sha512-6Nfm0MCVX3mpaR7YSCjmEO2GO8CDt6CX8ZpQnGdeu03WUCWtEPQ/uy0PUiNtIJjJZWnX0Cm3H55MOhbD1g+E/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "flowbite": "^2.0.0"
+      }
+    },
+    "node_modules/flowbite-svelte": {
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/flowbite-svelte/-/flowbite-svelte-0.46.0.tgz",
+      "integrity": "sha512-Qw4zX4nCbxP5ZemksC9/EVGE9WRnD8FsR5CrdZRxm1RGkMOv2nrKxDQ8MXHF/GwdEutFU5UeaQncQuqgY5DoVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.3",
+        "apexcharts": "^3.48.0",
+        "flowbite": "^2.3.0",
+        "tailwind-merge": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "pnpm": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -1738,7 +1916,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1790,7 +1967,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1835,7 +2011,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -1879,6 +2054,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -2022,6 +2203,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "license": "MIT",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
       }
     },
     "node_modules/minimatch": {
@@ -2206,7 +2396,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -2481,7 +2670,6 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
@@ -2527,7 +2715,7 @@
       "version": "4.52.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
       "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -2867,7 +3055,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2998,6 +3185,107 @@
         }
       }
     },
+    "node_modules/svg.draggable.js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/svg.draggable.js/-/svg.draggable.js-2.2.2.tgz",
+      "integrity": "sha512-JzNHBc2fLQMzYCZ90KZHN2ohXL0BQJGQimK1kGk6AvSeibuKcIdDX9Kr0dT9+UJ5O8nYA0RB839Lhvk4CY4MZw==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.easing.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/svg.easing.js/-/svg.easing.js-2.0.0.tgz",
+      "integrity": "sha512-//ctPdJMGy22YoYGV+3HEfHbm6/69LJUTAqI2/5qBvaNHZ9uUFVC82B0Pl299HzgH13rKrBgi4+XyXXyVWWthA==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": ">=2.3.x"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.filter.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/svg.filter.js/-/svg.filter.js-2.0.2.tgz",
+      "integrity": "sha512-xkGBwU+dKBzqg5PtilaTb0EYPqPfJ9Q6saVldX+5vCRy31P6TlRCP3U9NxH3HEufkKkpNgdTLBJnmhDHeTqAkw==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/svg.js/-/svg.js-2.7.1.tgz",
+      "integrity": "sha512-ycbxpizEQktk3FYvn/8BH+6/EuWXg7ZpQREJvgacqn46gIddG24tNNe4Son6omdXCnSOaApnpZw6MPCBA1dODA==",
+      "license": "MIT"
+    },
+    "node_modules/svg.pathmorphing.js": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/svg.pathmorphing.js/-/svg.pathmorphing.js-0.1.3.tgz",
+      "integrity": "sha512-49HWI9X4XQR/JG1qXkSDV8xViuTLIWm/B/7YuQELV5KMOPtXjiwH4XPJvr/ghEDibmLQ9Oc22dpWpG0vUDDNww==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.resize.js": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/svg.resize.js/-/svg.resize.js-1.4.3.tgz",
+      "integrity": "sha512-9k5sXJuPKp+mVzXNvxz7U0uC9oVMQrrf7cFsETznzUDDm0x8+77dtZkWdMfRlmbkEEYvUn9btKuZ3n41oNA+uw==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.6.5",
+        "svg.select.js": "^2.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.resize.js/node_modules/svg.select.js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-2.1.2.tgz",
+      "integrity": "sha512-tH6ABEyJsAOVAhwcCjF8mw4crjXSI1aa7j2VQR8ZuJ37H2MBUbyeqYr5nEO7sSN3cy9AR9DUwNg0t/962HlDbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.select.js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-3.0.1.tgz",
+      "integrity": "sha512-h5IS/hKkuVCbKSieR9uQCj9w+zLHoPh+ce19bBYyqF53g6mnPB8sAtIbe1s9dh2S2fCmYX2xel1Ln3PJBbK4kw==",
+      "license": "MIT",
+      "dependencies": {
+        "svg.js": "^2.6.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+      "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
@@ -3112,6 +3400,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@sveltejs/vite-plugin-svelte": "^3.0.2",
     "@tsconfig/svelte": "^5.0.2",
     "@types/dagre": "^0.7.51",
+    "@types/node": "^24.5.2",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
     "svelte": "^4.2.15",
@@ -24,6 +25,8 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^1.0.9",
-    "@xyflow/svelte": "^0.1.25"
+    "@xyflow/svelte": "^0.1.25",
+    "flowbite": "^2.5.2",
+    "flowbite-svelte": "^0.46.0"
   }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -13,6 +13,7 @@
   import ConfigurableNode from '$lib/components/ConfigurableNode.svelte';
   import { initialGraphData, loadGraphData } from '$lib/graphData';
   import { applyAutoLayout } from '$lib/layout';
+  import { DarkMode } from 'flowbite-svelte';
   import type {
     FlowEdge,
     FlowNode,
@@ -93,11 +94,20 @@
   }
 </script>
 
-<main class="flex h-screen flex-col overflow-hidden bg-slate-950 text-slate-100">
-  <header class="flex items-center justify-between border-b border-slate-800 bg-slate-900/70 px-6 py-3">
-    <h1 class="text-xl font-semibold">Svelte Flow Boilerplate</h1>
+<main class="flex h-screen flex-col overflow-hidden bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+  <header
+    class="flex items-center justify-between border-b border-gray-200 bg-white/80 px-6 py-3 backdrop-blur dark:border-gray-700 dark:bg-gray-900/80"
+  >
+    <div class="flex items-center gap-3">
+      <DarkMode
+        ariaLabel="Toggle dark mode"
+        class="focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700"
+        size="lg"
+      />
+      <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Svelte Flow Boilerplate</h1>
+    </div>
     <button
-      class="rounded bg-slate-800 px-4 py-2 text-sm font-medium uppercase tracking-wide transition hover:bg-slate-700"
+      class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-blue-700 focus:outline-none focus:ring-4 focus:ring-blue-300 dark:bg-blue-500 dark:hover:bg-blue-600 dark:focus:ring-blue-800"
       on:click={toggleLock}
     >
       {#if $lockStore}
@@ -110,7 +120,7 @@
 
   <section class="relative flex flex-1">
     {#if isLoading}
-      <div class="absolute inset-0 flex items-center justify-center text-slate-400">
+      <div class="absolute inset-0 flex items-center justify-center text-gray-500 dark:text-gray-400">
         Loading graph...
       </div>
     {/if}
@@ -126,12 +136,24 @@
       zoomOnPinch={!$lockStore}
       panOnScroll={!$lockStore}
       onconnect={handleConnect}
-      class="flex-1"
+      class="flex-1 bg-gray-50 dark:bg-gray-900 [--graph-bg:theme(colors.gray.50)] [--graph-pattern:theme(colors.gray.200)] [--graph-minimap-mask:rgba(17,24,39,0.15)] [--graph-control-bg:rgba(255,255,255,0.8)] [--graph-control-hover:rgba(226,232,240,0.9)] [--graph-control-border:theme(colors.gray.200)] dark:[--graph-bg:theme(colors.gray.900)] dark:[--graph-pattern:theme(colors.gray.600)] dark:[--graph-minimap-mask:rgba(15,23,42,0.5)] dark:[--graph-control-bg:rgba(17,24,39,0.85)] dark:[--graph-control-hover:rgba(55,65,81,0.7)] dark:[--graph-control-border:theme(colors.gray.700)]"
+      style="--background-color: var(--graph-bg); --background-pattern-color: var(--graph-pattern); --minimap-mask-color: var(--graph-minimap-mask); --controls-button-background-color: var(--graph-control-bg); --controls-button-background-color-hover: var(--graph-control-hover); --controls-button-border-color: var(--graph-control-border)"
       on:rename={handleRename}
     >
-      <MiniMap class="!bg-slate-900/70" />
-      <Controls position="bottom-left" class="!bg-slate-900/70" />
-      <Background variant={BackgroundVariant.Dots} gap={16} size={1.5} />
+      <MiniMap
+        class="!border !border-gray-200 !bg-white/90 text-gray-600 shadow-sm dark:!border-gray-700 dark:!bg-gray-800/90 dark:text-gray-300"
+      />
+      <Controls
+        position="bottom-left"
+        class="!rounded-lg !bg-white/90 !text-gray-600 shadow-sm dark:!bg-gray-800/90 dark:!text-gray-300"
+      />
+      <Background
+        variant={BackgroundVariant.Dots}
+        gap={16}
+        size={1.5}
+        bgColor="var(--graph-bg)"
+        patternColor="var(--graph-pattern)"
+      />
     </SvelteFlow>
   </section>
 </main>

--- a/src/app.css
+++ b/src/app.css
@@ -2,6 +2,4 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: dark;
-}
+

--- a/src/lib/components/ConfigurableNode.svelte
+++ b/src/lib/components/ConfigurableNode.svelte
@@ -62,25 +62,27 @@
   }
 </script>
 
-<div class="rounded-lg border border-slate-700 bg-slate-900/80 p-4 shadow-lg">
-  <h3 class="text-lg font-semibold text-slate-100">{data.label}</h3>
-  <div class="mt-4 flex gap-4 text-sm">
+<div
+  class="rounded-xl border border-gray-200 bg-white/90 p-4 shadow-lg shadow-gray-200/60 backdrop-blur dark:border-gray-700 dark:bg-gray-800/90 dark:shadow-black/20"
+>
+  <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{data.label}</h3>
+  <div class="mt-4 flex gap-4 text-sm text-gray-700 dark:text-gray-200">
     <div class="flex-1">
-      <p class="mb-2 font-medium uppercase tracking-wide text-slate-400">Inputs</p>
+      <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Inputs</p>
       <ul class="space-y-2">
         {#if data.inputs.length === 0}
-          <li class="text-xs italic text-slate-500">No inputs</li>
+          <li class="text-xs italic text-gray-400 dark:text-gray-500">No inputs</li>
         {:else}
           {#each data.inputs as input}
             <li class="relative">
               <Handle
-                class="absolute -left-3 top-1/2 h-3 w-3 -translate-y-1/2 rounded-full border border-emerald-300 bg-emerald-500/80"
+                class="absolute -left-3 top-1/2 h-3 w-3 -translate-y-1/2 rounded-full border border-emerald-300 bg-emerald-400 dark:border-emerald-500 dark:bg-emerald-500"
                 id={input.id}
                 position={Position.Left}
                 type="target"
               />
               <input
-                class="w-full rounded bg-slate-800/80 px-2 py-1 text-slate-100 outline-none focus:ring-2 focus:ring-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+                class="w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-900 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:focus:border-emerald-400 dark:focus:ring-emerald-400"
                 value={input.label}
                 on:change={(event) => onPortRename(event, 'input', input)}
                 disabled={isLocked}
@@ -91,21 +93,21 @@
       </ul>
     </div>
     <div class="flex-1">
-      <p class="mb-2 font-medium uppercase tracking-wide text-slate-400">Outputs</p>
+      <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Outputs</p>
       <ul class="space-y-2">
         {#if data.outputs.length === 0}
-          <li class="text-xs italic text-slate-500">No outputs</li>
+          <li class="text-xs italic text-gray-400 dark:text-gray-500">No outputs</li>
         {:else}
           {#each data.outputs as output}
             <li class="relative">
               <Handle
-                class="absolute -right-3 top-1/2 h-3 w-3 -translate-y-1/2 rounded-full border border-sky-300 bg-sky-500/80"
+                class="absolute -right-3 top-1/2 h-3 w-3 -translate-y-1/2 rounded-full border border-sky-300 bg-sky-400 dark:border-sky-500 dark:bg-sky-500"
                 id={output.id}
                 position={Position.Right}
                 type="source"
               />
               <input
-                class="w-full rounded bg-slate-800/80 px-2 py-1 text-slate-100 outline-none focus:ring-2 focus:ring-sky-400 disabled:cursor-not-allowed disabled:opacity-60"
+                class="w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-900 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-400 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:focus:border-sky-400 dark:focus:ring-sky-400"
                 value={output.label}
                 on:change={(event) => onPortRename(event, 'output', output)}
                 disabled={isLocked}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,8 +1,16 @@
+const flowbitePlugin = require('flowbite/plugin');
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./index.html', './src/**/*.{svelte,js,ts}'],
+  darkMode: 'class',
+  content: [
+    './index.html',
+    './src/**/*.{svelte,js,ts}',
+    './node_modules/flowbite-svelte/**/*.{js,ts,svelte}',
+    './node_modules/flowbite/**/*.js'
+  ],
   theme: {
     extend: {}
   },
-  plugins: []
+  plugins: [flowbitePlugin]
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "esnext",
     "target": "esnext",
     "lib": ["esnext", "dom"],
-    "types": ["svelte"],
+    "types": ["svelte", "node"],
     "baseUrl": ".",
     "paths": {
       "$lib/*": ["src/lib/*"],


### PR DESCRIPTION
## Summary
- add a Flowbite dark mode toggle to the layout header and apply Flowbite color tokens across the canvas controls
- restyle configurable nodes with Flowbite-inspired backgrounds, handles, and form inputs for light and dark themes
- configure Tailwind to scan Flowbite packages and include new dependencies required for Flowbite and Node typings

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3a9148ba08323814f8acde3d59a40